### PR TITLE
fix: symlink generic nginx log to stdout

### DIFF
--- a/alpine.armhf.Dockerfile
+++ b/alpine.armhf.Dockerfile
@@ -20,14 +20,14 @@ RUN set -eux &&  \
 	# 82 is the standard uid/gid for "www-data" in Alpine
 	# https://git.alpinelinux.org/aports/tree/main/nginx/nginx.pre-install
 	apk --no-cache add \
-		tzdata \
-		#git wget curl nano zip unzip \
-		supervisor \
-		nginx \
-		php7 php7-common php7-fpm php7-opcache \
+	tzdata \
+	#git wget curl nano zip unzip \
+	supervisor \
+	nginx \
+	php7 php7-common php7-fpm php7-opcache \
 	&& mkdir -p /run/nginx \
 	&& mkdir -p /etc/ssl/nginx \
-	&& mkdir -p /var/www/html \ 
+	&& mkdir -p /var/www/html \
 	&& chown -R $WWW_USER:$WWW_USER /var/www/html \
 	#&& chown -R $WWW_USER:$WWW_USER /var/tmp/nginx \
 	&& sed -i "s/ssl_session_cache shared:SSL:2m;/#ssl_session_cache shared:SSL:2m;/g" /etc/nginx/nginx.conf \
@@ -38,6 +38,7 @@ RUN set -eux &&  \
 	&& sed -i "s|;listen.group\s*=\s*nobody|listen.group = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
 	&& sed -i "s|user\s*=\s*nobody|user = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
 	&& sed -i "s|group\s*=\s*nobody|group = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
+	&& ln -sf /dev/stdout /var/log/nginx.log \
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log \
 	&& ln -sf /dev/stderr /var/log/php7/error.log \

--- a/alpine.armhf.extended.Dockerfile
+++ b/alpine.armhf.extended.Dockerfile
@@ -19,25 +19,25 @@ RUN set -eux &&  \
 	# 82 is the standard uid/gid for "www-data" in Alpine
 	# https://git.alpinelinux.org/aports/tree/main/nginx/nginx.pre-install
 	apk --no-cache add \
-		tzdata \
-		git wget curl nano zip unzip \
-		supervisor \
-		nginx \
-		php7 php7-common php7-fpm php7-opcache \
-		php7-soap php7-openssl php7-gmp php7-pdo_odbc php7-json php7-dom php7-pear \
-		php7-pdo php7-zip php7-mysqli php7-sqlite3 php7-pdo_pgsql php7-bcmath \
-		php7-gd php7-odbc php7-pdo_mysql php7-pdo_sqlite php7-gettext php7-xmlreader \
-		php7-xmlrpc php7-bz2 php7-iconv php7-pdo_dblib php7-curl php7-ctype \
-		php7-xml php7-phar php7-intl php7-mbstring php7-xsl php7-pgsql php7-session \
-		php7-imap php7-ldap php7-exif php7-fileinfo php7-dev php7-redis \
-		php7-pecl-mcrypt php7-pecl-yaml php7-pecl-imagick php7-pecl-imagick-dev \
-		php7-pecl-apcu php7-pecl-memcached php7-pecl-redis php7-pecl-couchbase \
-		# php7-mongodb php7-zlib \
-		composer \
+	tzdata \
+	git wget curl nano zip unzip \
+	supervisor \
+	nginx \
+	php7 php7-common php7-fpm php7-opcache \
+	php7-soap php7-openssl php7-gmp php7-pdo_odbc php7-json php7-dom php7-pear \
+	php7-pdo php7-zip php7-mysqli php7-sqlite3 php7-pdo_pgsql php7-bcmath \
+	php7-gd php7-odbc php7-pdo_mysql php7-pdo_sqlite php7-gettext php7-xmlreader \
+	php7-xmlrpc php7-bz2 php7-iconv php7-pdo_dblib php7-curl php7-ctype \
+	php7-xml php7-phar php7-intl php7-mbstring php7-xsl php7-pgsql php7-session \
+	php7-imap php7-ldap php7-exif php7-fileinfo php7-dev php7-redis \
+	php7-pecl-mcrypt php7-pecl-yaml php7-pecl-imagick php7-pecl-imagick-dev \
+	php7-pecl-apcu php7-pecl-memcached php7-pecl-redis php7-pecl-couchbase \
+	# php7-mongodb php7-zlib \
+	composer \
 	#&& curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer  \
 	&& mkdir -p /run/nginx \
 	&& mkdir -p /etc/ssl/nginx \
-	&& mkdir -p /var/www/html \ 
+	&& mkdir -p /var/www/html \
 	&& chown -R $WWW_USER:$WWW_USER /var/www/html \
 	#&& chown -R $WWW_USER:$WWW_USER /var/tmp/nginx \
 	&& sed -i "s/ssl_session_cache shared:SSL:2m;/#ssl_session_cache shared:SSL:2m;/g" /etc/nginx/nginx.conf \
@@ -48,6 +48,7 @@ RUN set -eux &&  \
 	&& sed -i "s|;listen.group\s*=\s*nobody|listen.group = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
 	&& sed -i "s|user\s*=\s*nobody|user = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
 	&& sed -i "s|group\s*=\s*nobody|group = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
+	&& ln -sf /dev/stdout /var/log/nginx.log \
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log \
 	&& ln -sf /dev/stderr /var/log/php7/error.log \

--- a/alpine.x86_64.Dockerfile
+++ b/alpine.x86_64.Dockerfile
@@ -20,14 +20,14 @@ RUN set -eux &&  \
 	# 82 is the standard uid/gid for "www-data" in Alpine
 	# https://git.alpinelinux.org/aports/tree/main/nginx/nginx.pre-install
 	apk --no-cache add \
-		tzdata \
-		#git wget curl nano zip unzip \
-		supervisor \
-		nginx \
-		php7 php7-common php7-fpm php7-opcache \
+	tzdata \
+	#git wget curl nano zip unzip \
+	supervisor \
+	nginx \
+	php7 php7-common php7-fpm php7-opcache \
 	&& mkdir -p /run/nginx \
 	&& mkdir -p /etc/ssl/nginx \
-	&& mkdir -p /var/www/html \ 
+	&& mkdir -p /var/www/html \
 	&& chown -R $WWW_USER:$WWW_USER /var/www/html \
 	#&& chown -R $WWW_USER:$WWW_USER /var/tmp/nginx \
 	&& sed -i "s/ssl_session_cache shared:SSL:2m;/#ssl_session_cache shared:SSL:2m;/g" /etc/nginx/nginx.conf \
@@ -38,6 +38,7 @@ RUN set -eux &&  \
 	&& sed -i "s|;listen.group\s*=\s*nobody|listen.group = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
 	&& sed -i "s|user\s*=\s*nobody|user = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
 	&& sed -i "s|group\s*=\s*nobody|group = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
+	&& ln -sf /dev/stdout /var/log/nginx.log \
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log \
 	&& ln -sf /dev/stderr /var/log/php7/error.log \

--- a/alpine.x86_64.extended.Dockerfile
+++ b/alpine.x86_64.extended.Dockerfile
@@ -20,25 +20,25 @@ RUN set -eux &&  \
 	# 82 is the standard uid/gid for "www-data" in Alpine
 	# https://git.alpinelinux.org/aports/tree/main/nginx/nginx.pre-install
 	apk --no-cache add \
-		tzdata \
-		git wget curl nano zip unzip \
-		supervisor \
-		nginx \
-		php7 php7-common php7-fpm php7-opcache \
-		php7-soap php7-openssl php7-gmp php7-pdo_odbc php7-json php7-dom php7-pear \
-		php7-pdo php7-zip php7-mysqli php7-sqlite3 php7-pdo_pgsql php7-bcmath \
-		php7-gd php7-odbc php7-pdo_mysql php7-pdo_sqlite php7-gettext php7-xmlreader \
-		php7-xmlrpc php7-bz2 php7-iconv php7-pdo_dblib php7-curl php7-ctype \
-		php7-xml php7-phar php7-intl php7-mbstring php7-xsl php7-pgsql php7-session \
-		php7-imap php7-ldap php7-exif php7-fileinfo php7-dev php7-redis \
-		php7-pecl-mcrypt php7-pecl-yaml php7-pecl-imagick php7-pecl-imagick-dev \
-		php7-pecl-apcu php7-pecl-memcached php7-pecl-redis php7-pecl-couchbase \
-		# php7-mongodb php7-zlib \
-		composer \
+	tzdata \
+	git wget curl nano zip unzip \
+	supervisor \
+	nginx \
+	php7 php7-common php7-fpm php7-opcache \
+	php7-soap php7-openssl php7-gmp php7-pdo_odbc php7-json php7-dom php7-pear \
+	php7-pdo php7-zip php7-mysqli php7-sqlite3 php7-pdo_pgsql php7-bcmath \
+	php7-gd php7-odbc php7-pdo_mysql php7-pdo_sqlite php7-gettext php7-xmlreader \
+	php7-xmlrpc php7-bz2 php7-iconv php7-pdo_dblib php7-curl php7-ctype \
+	php7-xml php7-phar php7-intl php7-mbstring php7-xsl php7-pgsql php7-session \
+	php7-imap php7-ldap php7-exif php7-fileinfo php7-dev php7-redis \
+	php7-pecl-mcrypt php7-pecl-yaml php7-pecl-imagick php7-pecl-imagick-dev \
+	php7-pecl-apcu php7-pecl-memcached php7-pecl-redis php7-pecl-couchbase \
+	# php7-mongodb php7-zlib \
+	composer \
 	#&& curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer  \
 	&& mkdir -p /run/nginx \
 	&& mkdir -p /etc/ssl/nginx \
-	&& mkdir -p /var/www/html \ 
+	&& mkdir -p /var/www/html \
 	&& chown -R $WWW_USER:$WWW_USER /var/www/html \
 	#&& chown -R $WWW_USER:$WWW_USER /var/tmp/nginx \
 	&& sed -i "s/ssl_session_cache shared:SSL:2m;/#ssl_session_cache shared:SSL:2m;/g" /etc/nginx/nginx.conf \
@@ -49,6 +49,7 @@ RUN set -eux &&  \
 	&& sed -i "s|;listen.group\s*=\s*nobody|listen.group = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
 	&& sed -i "s|user\s*=\s*nobody|user = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
 	&& sed -i "s|group\s*=\s*nobody|group = ${WWW_USER}|g" /etc/php7/php-fpm.d/www.conf \
+	&& ln -sf /dev/stdout /var/log/nginx.log \
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log \
 	&& ln -sf /dev/stderr /var/log/php7/error.log \


### PR DESCRIPTION
I noticed that at some point my container on ECS runs out of storage space because it seems to be writing logs to `/var/log/nginx.log`. 
This PR ensures `/var/log/nginx.log` logs to `stdout` to prevent that from happening.